### PR TITLE
updated configuration per upgrade docs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -87,20 +87,6 @@ def configureReactNativePom(def pom) {
 
 afterEvaluate { project ->
 
-    task androidJavadoc(type: Javadoc) {
-        source = android.sourceSets.main.java.srcDirs
-        classpath += files(android.bootClasspath)
-        project.getConfigurations().getByName('implementation').setCanBeResolved(true)
-        classpath += files(project.getConfigurations().getByName('implementation').asList())
-
-        include '**/*.java'
-    }
-
-    task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
-        classifier = 'javadoc'
-        from androidJavadoc.destinationDir
-    }
-
     task androidSourcesJar(type: Jar) {
         classifier = 'sources'
         from android.sourceSets.main.java.srcDirs
@@ -116,16 +102,9 @@ afterEvaluate { project ->
 
     artifacts {
         archives androidSourcesJar
-        archives androidJavadocJar
     }
 
     task installArchives(type: Upload) {
         configuration = configurations.archives
-        repositories.maven {
-            // Deploy to react-native-event-bridge/maven, ready to publish to npm
-            url = "file://${projectDir}/../android/maven"
-
-            // configureReactNativePom pom
-        }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -90,7 +90,9 @@ afterEvaluate { project ->
     task androidJavadoc(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += files(android.bootClasspath)
-        classpath += files(project.getConfigurations().getByName('compile').asList())
+        project.getConfigurations().getByName('implementation').setCanBeResolved(true)
+        classpath += files(project.getConfigurations().getByName('implementation').asList())
+
         include '**/*.java'
     }
 


### PR DESCRIPTION
`compile` is no longer a valid configuration.  Modified per upgrade docs and tested against project running `react-native 0.68.1`

https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal